### PR TITLE
防止 AnimationTools 中格式错误时程序闪退

### DIFF
--- a/AnimationLibrary/AnimationBundleReader.cs
+++ b/AnimationLibrary/AnimationBundleReader.cs
@@ -175,6 +175,19 @@ namespace AnimationLibrary
             return hashTable;
         }
 
+        private void tryOpenStream(string bild_file, string anim_file)
+        {
+            try
+            {
+                if (bildStream == null)
+                    bildStream = new FileStream(bild_file, FileMode.Open);
+                if (animStream == null)
+                    animStream = new FileStream(anim_file, FileMode.Open);
+            }
+            catch (System.IO.FileNotFoundException)
+            {
+            }
+        }
         public DataSet ReadFile(string path, int winth, int height)
         {
             DataSet data = new DataSet();
@@ -188,8 +201,17 @@ namespace AnimationLibrary
             animTable = new DataTable();
             animTable.TableName = nameof(animTable);
 
-            bildStream = new FileStream(path + "_build.txt", FileMode.Open);
-            animStream = new FileStream(path + "_anim.txt", FileMode.Open);
+            // open bildStream and animStream
+            string fileNamePrefix = Path.GetFileName(path);
+            string dirName = Path.GetDirectoryName(path);
+            string parentDirName = Path.GetDirectoryName(dirName);
+            string textAssetDir = Path.Combine(parentDirName, "TextAsset");
+            string textAssetPrefix = Path.Combine(textAssetDir, fileNamePrefix);
+            tryOpenStream(path + "_build.txt", path + "_anim.txt");
+            tryOpenStream(path + "_build.prefab", path + "_anim.prefab");
+            tryOpenStream(textAssetPrefix + "_build.txt", textAssetPrefix + "_anim.txt");
+            tryOpenStream(textAssetPrefix + "_build.prefab", textAssetPrefix + "_anim.prefab");
+            if (bildStream == null || animStream == null) throw new System.IO.FileNotFoundException("No build or anim file.");
 
             bildReader = new BinaryReader(bildStream, Encoding.UTF8);
             animReader = new BinaryReader(animStream, Encoding.UTF8);

--- a/AnimationTools/MainWindow.xaml.cs
+++ b/AnimationTools/MainWindow.xaml.cs
@@ -196,13 +196,29 @@ namespace AnimationTools
         {
             bundles = new AnimationBundleReader();
             file = ListBoxFileList.SelectedItem.ToString();
-            path = file.Remove(file.LastIndexOf('_'));
+            try
+            {
+                path = file.Remove(file.LastIndexOf('_'));
+            }
+            catch (System.ArgumentOutOfRangeException)
+            {
+                mVariableData.TipContents = "解包" + name + "失败：图片文件名格式错误";
+                return;
+            }
             name = file.Replace("/", "\\");
             name = name.Substring(name.LastIndexOf("\\") + 1, (name.LastIndexOf(".") - name.LastIndexOf("\\") - 1));
             Directory.CreateDirectory(path);
 
             System.Drawing.Image source = System.Drawing.Image.FromFile(file);
-            dataset = bundles.ReadFile(path, source.Width, source.Height);
+            try
+            {
+                dataset = bundles.ReadFile(path, source.Width, source.Height);
+            }
+            catch (System.IO.FileNotFoundException)
+            {
+                mVariableData.TipContents = "解包" + name + "失败：找不到对应 build/anim 文件";
+                return;
+            }
             //dataGridView1.DataSource = ds.Tables["animTable"];
 
             ExportTexture();


### PR DESCRIPTION
以及顺便尝试从 `../TextAsset` 中查找 build 和 anim 文件，方便直接使用从 [AssetStudio](https://github.com/Perfare/AssetStudio/releases) 导出的素材。

This is a reopened PR of #3 to switch source branch.